### PR TITLE
Fix Input and RichEditor Styles (Fixes #5)

### DIFF
--- a/styles/theme-colors.less
+++ b/styles/theme-colors.less
@@ -1,3 +1,0 @@
-@import 'variables';
-@component-active-color: @arc-accent;
-@toolbar-background-color: @arc-dark;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -4,7 +4,10 @@
 @accent-primary: @arc-light;
 @accent-primary-dark: darken(@arc-light, 20%);
 
+@background-gradient: none;
+@background-primary: @arc-dark;
 @background-secondary: @arc-dark;
+
 @text-color: @arc-light;
 @text-color-subtle: lighten(@arc-dark, 40%);
 @text-color-very-subtle: @arc-light;
@@ -14,7 +17,8 @@
 
 @panel-background-color: @arc-dark;
 @toolbar-background-color: @arc-dark;
+@component-active-color: @arc-accent;
 
 @btn-default-bg-color: @arc-dark;
 @btn-default-text-color: @arc-light;
-@background-gradient: none;
+@input-bg: @arc-dark;


### PR DESCRIPTION
- Removed apparently `duplicate theme-colors.less`
- Defined `background-primary` (RichEditors inherit their background color from this)
- Defined `input-bg` (Inputs inherit their background color from this)